### PR TITLE
Feature/#2 add app skeleton

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+kms_back-*.tar
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# Kms-Back
-The API behind the Kms Application.
+# KmsBack
+
+This is the back-end behind the Kms application.
+
+## TODO

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,28 @@
+use Mix.Config
+
+# This configuration is loaded before any dependency and is restricted
+# to this project. If another project depends on this project, this
+# file won't be loaded nor affect the parent project. For this reason,
+# if you want to provide default values for your application for
+# 3rd-party users, it should be done in your "mix.exs" file.
+
+# You can configure your application as:
+#
+#     config :kms_back, key: :value
+#
+# and access this configuration in your application as:
+#
+#     Application.get_env(:kms_back, :key)
+#
+# You can also configure a 3rd-party app:
+#
+#     config :logger, level: :info
+#
+
+# It is also possible to import configuration files, relative to this
+# directory. For example, you can emulate configuration per environment
+# by uncommenting the line below and defining dev.exs, test.exs and such.
+# Configuration from the imported file will override the ones defined
+# here (which is why it is important to import them last).
+#
+#     import_config "#{Mix.env()}.exs"

--- a/lib/kms_back.ex
+++ b/lib/kms_back.ex
@@ -1,0 +1,18 @@
+defmodule KmsBack do
+  @moduledoc """
+  Documentation for KmsBack.
+  """
+
+  @doc """
+  Hello world.
+
+  ## Examples
+
+      iex> KmsBack.hello()
+      :world
+
+  """
+  def hello do
+    :world
+  end
+end

--- a/lib/kms_back/application.ex
+++ b/lib/kms_back/application.ex
@@ -1,0 +1,20 @@
+defmodule KmsBack.Application do
+  # See https://hexdocs.pm/elixir/Application.html
+  # for more information on OTP Applications
+  @moduledoc false
+
+  use Application
+
+  def start(_type, _args) do
+    # List all child processes to be supervised
+    children = [
+      # Starts a worker by calling: KmsBack.Worker.start_link(arg)
+      # {KmsBack.Worker, arg},
+    ]
+
+    # See https://hexdocs.pm/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: KmsBack.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -19,6 +19,11 @@ defmodule KmsBack.MixProject do
   end
 
   defp deps do
-    []
+    [
+      {:cowboy, "~> 2.5"},
+      {:plug, "~> 1.6"},
+      {:poison, "~> 4.0"},
+      {:postgrex, "~> 0.13.5"}
+    ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,24 @@
+defmodule KmsBack.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :kms_back,
+      version: "0.1.0",
+      elixir: "~> 1.7",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger],
+      mod: {KmsBack.Application, []}
+    ]
+  end
+
+  defp deps do
+    []
+  end
+end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,12 @@
+%{
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
+  "cowboy": {:hex, :cowboy, "2.5.0", "4ef3ae066ee10fe01ea3272edc8f024347a0d3eb95f6fbb9aed556dacbfc1337", [:rebar3], [{:cowlib, "~> 2.6.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.6.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
+  "cowlib": {:hex, :cowlib, "2.6.0", "8aa629f81a0fc189f261dc98a42243fa842625feea3c7ec56c48f4ccdb55490f", [:rebar3], [], "hexpm"},
+  "db_connection": {:hex, :db_connection, "1.1.3", "89b30ca1ef0a3b469b1c779579590688561d586694a3ce8792985d4d7e575a61", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
+  "decimal": {:hex, :decimal, "1.5.0", "b0433a36d0e2430e3d50291b1c65f53c37d56f83665b43d79963684865beab68", [:mix], [], "hexpm"},
+  "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
+  "plug": {:hex, :plug, "1.6.4", "35618dd2cc009b69b000f785452f6b370f76d099ece199733fea27bc473f809d", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.4", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm"},
+  "postgrex": {:hex, :postgrex, "0.13.5", "3d931aba29363e1443da167a4b12f06dcd171103c424de15e5f3fc2ba3e6d9c5", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"},
+  "ranch": {:hex, :ranch, "1.6.2", "6db93c78f411ee033dbb18ba8234c5574883acb9a75af0fb90a9b82ea46afa00", [:rebar3], [], "hexpm"},
+}

--- a/test/kms_back_test.exs
+++ b/test/kms_back_test.exs
@@ -1,0 +1,8 @@
+defmodule KmsBackTest do
+  use ExUnit.Case
+  doctest KmsBack
+
+  test "greets the world" do
+    assert KmsBack.hello() == :world
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
This pull request adds the skeleton application to make a back-end with Elixir.

# How to generate an application?

Elixir comes with a CLI tool named Mix, this utility play the same role as NPM, we can create an application, install dependencies, etc.. through a lot of commands.

https://hexdocs.pm/mix/Mix.html

## Arguments

We use the following command:

`mix new KmsBack --sup --app kms_back --module KmsBack`

Here the purpose of the different parts:

- `mix new`: Create a new application (the following name is the folder name)
- `--sup`: add a supervision tree to the applicatio (see `lib/kms_back/application.ex`)
- `--app`: set the name of the application (in some configuration files)
- `--module`: set the name of the application (in each modules)

# Utilities

`.formatter.exs`: Elixir come with a formatter. It do the same as `Prettier` with `ESLint`, with a propoer extension we can auto-format the code in our editor.

# Dependencies

We need the following packages:

- `cowboy`: a simple HTTP server (based on Erlang)
- `plug`: a tool to "compose" module in a web app (provide a router, the mecanism of controller, etc...)
- `poison`: a package to play with JSON (encoding and decoding)
- `postgrex`: a PostgreSQL driver for Elixir